### PR TITLE
Add Elispeak to Educational AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ Artificial intelligence tools are software applications that utilize machine lea
 - [Khan Academy](https://www.khanacademy.org/) - Educational platform with Khanmigo AI tutor powered by GPT-4.
 - [Coursera](https://www.coursera.org/) - Online courses with AI recommendations and career coaching.
 - [Duolingo](https://www.duolingo.com/) - Language learning with Duolingo Max AI features and roleplay.
+- [Elispeak](https://app.elispeak.com/?freemium=true) - AI English speaking coach for live voice conversations on everyday, work, travel, and IELTS/TOEFL topics; 15 free minutes of practice per day in the browser.
 - [Socratic by Google](https://socratic.org/) - AI homework helper with step-by-step explanations.
 - [Photomath](https://photomath.com/) - Math problem solver with camera scanning and explanations.
 - [Quizlet](https://quizlet.com/) - AI-powered flashcards and study tools with Q-Chat tutor.


### PR DESCRIPTION
Adds a single line under **Research & Education → Educational AI Tools**, right after Duolingo.

**[Elispeak](https://app.elispeak.com/?freemium=true)** — an AI English speaking coach for live voice conversations on everyday, work, travel, and IELTS/TOEFL topics; 15 free minutes of practice per day in the browser.

Fits alongside Duolingo (language learning with AI) but differs in primary modality — Elispeak is voice-first (you actually talk out loud), Duolingo is text/tap-first with optional roleplay. Entry is factual, one line, matches the section's format; no other entries reordered.

## Summary by Sourcery

Documentation:
- Document Elispeak as an AI English speaking coach under Educational AI Tools alongside existing entries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Elispeak to the Research & Education → Educational AI Tools list in the README. It’s a voice-first English speaking coach for live conversations (everyday, work, travel, IELTS/TOEFL) with 15 free minutes per day, placed after Duolingo.

<sup>Written for commit a35f98d695ef27875d34f4f46142cd08b628584c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Elispeak to the "Educational AI Tools" section in the README, providing users with information about this new educational AI resource alongside other available tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->