### PR TITLE
Add CV Mirror (free ATS scanner) + AimVantage to Career & Job Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,8 @@ Artificial intelligence tools are software applications that utilize machine lea
 - [Jobscan](https://www.jobscan.co/) - Resume and LinkedIn optimization with ATS keyword matching.
 - [Resume Worded](https://resumeworded.com/) - AI resume and LinkedIn feedback with score and targeted advice.
 - [Kickresume](https://www.kickresume.com/) - AI resume builder with templates and job matching.
+- [CV Mirror](https://cv-mirror-web.vercel.app/) - Free, fully client-side ATS scanner. Simulates how 5 real ATS systems (Workday, Greenhouse, Lever, Taleo, iCIMS) parse a CV side by side. Reading-order overlay, vendor-specific lint, no fake score. Nothing uploads.
+- [Vantage AI](https://vantage-livid.vercel.app/) - AI job preparation tool. Upload CV, paste job link, get the full prep pack (company brief, tailored cover letter, mock interview, fit score, 5-min pitch outline) in 90 seconds.
 
 
 

--- a/README.md
+++ b/README.md
@@ -508,8 +508,8 @@ Artificial intelligence tools are software applications that utilize machine lea
 - [Jobscan](https://www.jobscan.co/) - Resume and LinkedIn optimization with ATS keyword matching.
 - [Resume Worded](https://resumeworded.com/) - AI resume and LinkedIn feedback with score and targeted advice.
 - [Kickresume](https://www.kickresume.com/) - AI resume builder with templates and job matching.
-- [CV Mirror](https://cv-mirror-web.vercel.app/) - Free, fully client-side ATS scanner. Simulates how 5 real ATS systems (Workday, Greenhouse, Lever, Taleo, iCIMS) parse a CV side by side. Reading-order overlay, vendor-specific lint, no fake score. Nothing uploads.
-- [Vantage AI](https://vantage-livid.vercel.app/) - AI job preparation tool. Upload CV, paste job link, get the full prep pack (company brief, tailored cover letter, mock interview, fit score, 5-min pitch outline) in 90 seconds.
+- [CV Mirror](https://cv-mirror-web.vercel.app/) - Client-side ATS resume scanner that compares parser output across multiple systems.
+- [Vantage AI](https://vantage-livid.vercel.app/) - AI job prep tool that generates company research, cover letters, mock interview questions, and CV fit analysis.
 
 
 


### PR DESCRIPTION
## What's being added

Two free/freemium AI career tools built in the UK:

| Tool | Category | Description |
|------|----------|-------------|
| [CV Mirror](https://cv-mirror-web.vercel.app/) | ATS Scanner | Free, open-source ATS resume linter — parses your CV through simulated Workday/Greenhouse/Lever/Taleo/iCIMS pipelines |
| [AimVantage](https://aimvantage.uk) | Job Preparation | AI job preparation platform — ATS scanning, tailored cover letters (4 tones), mock interviews with AI grading, CV-to-job fit scoring |

Both by the same UK indie builder ([Giovanni Sizino Ennes](https://github.com/goofypluto999)).

> Note: AimVantage was formerly called "Vantage AI" — rebranded May 2026 to match the aimvantage.uk domain.