### PR TITLE
Add AdDogs to Design Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Artificial intelligence tools are software applications that utilize machine lea
 - [LogoAI](https://www.logoai.com/) - AI logo generator with brand kit creation.
 - [Brandmark](https://brandmark.io/) - AI brand identity generator with color palettes.
 - [Looka](https://looka.com/) - AI logo maker with full brand kit.
+- [AdDogs](https://www.addogs.ai/) - AI ad creative generator that clones any winning ad design and applies your product photo and brand identity.
 
 
 


### PR DESCRIPTION
Adds [AdDogs](https://www.addogs.ai) to the Design Tools section.

**What it is:** AI ad creative generator. Pick any winning ad design, upload your product photo, and the AI recreates the ad with your product — preserving the original layout, style, and composition. Brand colors and logo are extracted automatically.

**Why Design Tools:** It sits naturally alongside Canva AI, Mockup Photos, and Looka — generative design with brand kit application. Compared to Looka (logos) and Mockup Photos (mockups), AdDogs is specialized for ad creatives across 14 aspect ratios.

**Why I'm submitting:** Real, public, working product. Free tier available; paid plans from $12/mo.

Happy to revise wording or move sections if a different category fits better. Thanks for maintaining the list.

## Summary by Sourcery

Documentation:
- Document AdDogs as an AI ad creative generator alongside existing design tools.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added AdDogs to the Design Tools section in README. Expands the list with an ad creative generator that clones winning ad designs and applies your product photo and brand identity.

<sup>Written for commit 6e96c05579de432594fb31f3bd2c6dd13ce79d2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AdDogs to the Design Tools section under Creativity & Design in the README. This new resource expands the collection of design tools available to users, providing an additional option for those seeking to enhance their creative workflows and design capabilities. The entry is positioned to complement existing design resources and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->