### PR TITLE
Add NotFair (Google Ads MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ Artificial intelligence tools are software applications that utilize machine lea
 - [Drift](https://www.drift.com/) - Conversational marketing platform with AI chatbots.
 - [Lavender](https://www.lavender.ai/) - AI email coach for sales with real-time suggestions.
 - [Seamless.ai](https://seamless.ai/) - AI-powered B2B lead generation and prospecting.
+- [NotFair](https://notfair.co) - Google Ads MCP server. Connects Claude and AI agents to a Google Ads account: diagnose campaign performance, recommend optimizations, and execute approved campaign changes via the Google Ads API.
 
 ### E-commerce & Retail
 


### PR DESCRIPTION
Adding NotFair under Marketing & Sales. It's a Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Free tier + paid plans. Listed in the official MCP registry as io.github.nowork-studio/notfair. Source: github.com/nowork-studio/toprank.

Happy to adjust the format if you'd prefer.

## Summary by Sourcery

Documentation:
- Document the NotFair Google Ads MCP server in the Marketing & Sales tools list, describing its purpose and capabilities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add NotFair to the Marketing & Sales list in the README. It’s a Google Ads MCP server that lets Claude and other agents analyze campaign performance, suggest optimizations, and execute approved changes via the Google Ads API.

<sup>Written for commit 0b25901886f88c5bdc5f680a9a4b10fbd559b353. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added NotFair to the Business & Marketing → Marketing & Sales resources section.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aliammari1/awesome-ai-tools/pull/67)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->