### PR TITLE
Add CoderPlan - unified LLM API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Artificial intelligence tools are software applications that utilize machine lea
 - [Haystack](https://haystack.deepset.ai/) - NLP framework for building search systems and RAG pipelines.
 - [Hugging Face](https://huggingface.co/) - ML model hub with models, datasets, and Inference Endpoints.
 - [OpenRouter](https://openrouter.ai/) - Unified API for 100+ LLMs with cost optimization and fallbacks.
+- [CoderPlan](https://coderplan.ai/) - Unified LLM API gateway with Claude, OpenAI, and Gemini. Pay-per-use billing, China-optimized with Alipay/WeChat.
 - [Poe](https://poe.com/) - Platform for accessing multiple AI chatbots with custom bots.
 - [Together AI](https://together.ai/) - Inference and fine-tuning platform for open-source LLMs.
 - [Replicate](https://replicate.com/) - Run open-source models in the cloud with simple API.


### PR DESCRIPTION
Add CoderPlan to the LLM Tools and Frameworks section.

CoderPlan is a unified LLM API gateway compatible with the OpenAI protocol:
- One API endpoint for Claude, GPT, Gemini, DeepSeek, and Qwen
- OpenAI-compatible API - drop-in replacement
- Pay-per-use pricing, supports Alipay/WeChat
- Targeted at developers using Claude Code, Codex CLI, Cursor, and Cline

Placed alongside OpenRouter in the LLM Tools and Frameworks section.

## Summary by Sourcery

Documentation:
- Document CoderPlan as a unified OpenAI-compatible LLM API gateway alongside other LLM tools and frameworks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added CoderPlan to the LLM Tools & Frameworks list as a unified API gateway for Claude, OpenAI, and Gemini. Includes pay‑per‑use billing and China‑optimized payments (Alipay/WeChat), providing a complementary option alongside OpenRouter.

<sup>Written for commit 49750f4d9b92350b94f168726dcc2dbe41432ad1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aliammari1/awesome-ai-tools/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "CoderPlan" to the LLM Tools & Frameworks reference list. The new entry appears between OpenRouter and Poe, updating the tools index to reflect the expanded set of available options.
  * Minor formatting adjustment to integrate the new entry smoothly into the existing list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->