### PR TITLE
Add Xquik and disambiguate YOLO entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ The fastest-moving corner of the field in 2026: autonomous and semi-autonomous s
 
 ### Specialized Vision Tools
 
-- [YOLO](https://github.com/ultralytics/ultralytics) - Real-time object detection with C2PSA module.
-- [YOLO](https://pjreddie.com/darknet/yolo/) - Real-time object detection framework.
+- [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) - Real-time object detection with C2PSA module.
+- [Darknet YOLO](https://pjreddie.com/darknet/yolo/) - Real-time object detection framework.
 - [Detectron2](https://github.com/facebookresearch/detectron2) - Facebook's detection framework.
 - [MediaPipe](https://mediapipe.dev/) - Google's ML framework for live perception.
 - [Face++](https://www.faceplusplus.com/) - Face recognition platform.
@@ -646,6 +646,9 @@ The fastest-moving corner of the field in 2026: autonomous and semi-autonomous s
 - [Devin AI](https://cognition.ai/) - Autonomous AI software developer agent for full SDLC.
 - [Harvey AI](https://harvey.ai/) - AI agent for automating legal workflows and contract review.
 - [Dust](https://dust.tt/) - AI assistant builder for enterprise with custom agents and data sources.
+- [Xquik](https://xquik.com/en) - Automates X workflows through REST, webhooks, and MCP.
+
+> Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 
 ### Specialized AI Applications
 


### PR DESCRIPTION
## Description

Add Xquik to the curated AI Agents & Automation list. Also fix an independent catalogue ambiguity by giving the Ultralytics and Darknet YOLO entries distinct names.

## Type of Change

- [x] Adding a new AI tool
- [x] Updating existing tool information
- [ ] Fixing a broken link
- [ ] Re-categorizing a tool
- [x] Documentation improvement
- [ ] Other

## Independent Repository Fix

The catalogue displayed both Ultralytics and Darknet as `YOLO`. The duplicate label made search results and visual scanning ambiguous. This PR renames the entries to `Ultralytics YOLO` and `Darknet YOLO` without changing their destinations.

## Review Audit

- Read every issue comment, submitted review, check, workflow run, and lifecycle event.
- Confirmed there are 0 review threads and 0 inline comments.
- All runnable review, security, and static-analysis checks reported no actionable issue on the prior head.
- GitHub CI has zero jobs until a maintainer approves the fork workflow.
- Squashed the branch to 1 signed commit based on current upstream `main`.

## Validation

- `awesome-lint` passes against upstream repository metadata.
- All 3 affected links return HTTP 200.
- Xquik description stays under 120 characters.
- Markdown entry names are unique after the YOLO correction.
- `git diff --check upstream/main...HEAD` passes.

## Tool Information

- **Name**: Xquik
- **URL**: https://xquik.com/en
- **Category**: AI Agents & Automation
- **Description**: Automates X workflows through REST, webhooks, and MCP.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/aliammari1/awesome-ai-tools/blob/main/CONTRIBUTING.md)
- [x] The tool meets the quality criteria
- [x] The description follows the requested format
- [x] The description is under 120 characters
- [x] The entry is in the most specific subcategory
- [x] I verified every affected link
- [x] `awesome-lint` passes against upstream metadata
- [x] The independent repository fix is included

## License Acknowledgment

By submitting this PR, I dedicate my contribution to the public domain under the repository CC0 1.0 Universal dedication.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the specialized vision tools list by distinguishing Ultralytics YOLO and Darknet YOLO.
  * Added Xquik to the AI Agents & Automation tools list.
  * Included a trademark and affiliation disclaimer for Xquik.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->