### PR TITLE
Add HairWow to design tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Artificial intelligence tools are software applications that utilize machine lea
 - [Penpot](https://penpot.app/) - Open-source design platform with AI features and collaboration.
 - [Spline](https://spline.design/) - 3D design with AI generation and web export.
 - [Mockup Photos](https://mockup.photos/) - AI-generated mockups with templates.
+- [HairWow](https://www.gohairwow.com/) - AI hairstyle try-on and hair-care guidance for previewing haircuts, colors, bangs, layers, and beard styles on your own photo.
 - [LogoAI](https://www.logoai.com/) - AI logo generator with brand kit creation.
 - [Brandmark](https://brandmark.io/) - AI brand identity generator with color palettes.
 - [Looka](https://looka.com/) - AI logo maker with full brand kit.


### PR DESCRIPTION
Adds HairWow to the Design Tools section. HairWow helps users preview hairstyles, colors, bangs, layers, and beard styles on their own photo before making a salon or barber decision.

## Summary by Sourcery

Documentation:
- Document the HairWow AI hairstyle try-on and hair-care guidance tool in the Design Tools section of the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added HairWow to the Design Tools section in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->