### PR TITLE
Add DaoXE multi-model multi-protocol API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ The fastest-moving corner of the field in 2026: autonomous and semi-autonomous s
 - [LM Studio](https://lmstudio.ai/) - Desktop app for running local LLMs with chat UI.
 - [vLLM](https://vllm.ai/) - High-throughput LLM serving with PagedAttention.
 - [Anyscale](https://www.anyscale.com/) - Scalable LLM deployment with Ray framework.
-- [DaoXE](https://daoxe.com) - Multi-model multi-protocol AI API gateway for Chat Completions, Responses, and Anthropic Messages.
+- [DaoXE](https://daoxe.com) - Multi-model multi-protocol AI API gateway (Chat Completions, Responses, Anthropic Messages, image APIs).
 - [Future AGI](https://github.com/future-agi/future-agi) - Open-source self-hostable end-to-end agent engineering and optimization platform unifying tracing, evaluation, simulation, datasets, gateway, and guardrails in one feedback loop.
 
 

--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ The fastest-moving corner of the field in 2026: autonomous and semi-autonomous s
 - [LM Studio](https://lmstudio.ai/) - Desktop app for running local LLMs with chat UI.
 - [vLLM](https://vllm.ai/) - High-throughput LLM serving with PagedAttention.
 - [Anyscale](https://www.anyscale.com/) - Scalable LLM deployment with Ray framework.
+- [DaoXE](https://daoxe.com) - Multi-model multi-protocol AI API gateway for Chat Completions, Responses, and Anthropic Messages.
 - [Future AGI](https://github.com/future-agi/future-agi) - Open-source self-hostable end-to-end agent engineering and optimization platform unifying tracing, evaluation, simulation, datasets, gateway, and guardrails in one feedback loop.
 
 


### PR DESCRIPTION
## Description
Add [DaoXE](https://daoxe.com), a multi-model, multi-protocol AI API gateway for developers, under **LLM Tools & Frameworks**. It exposes OpenAI Chat Completions, OpenAI Responses, Anthropic Messages (Claude protocol), and image-generation-compatible endpoints — not OpenAI-only and not Claude-only. Public examples/benchmarks: https://github.com/seven7763/DaoXE-AI

## Type of Change
- [x] Adding a new AI tool

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] The tool meets our quality criteria (active, reputable, functional)
- [x] The description follows our format: `- [Name](URL) - Description.`
- [x] Description is under 120 characters
- [x] The entry is in the most specific subcategory and alphabetically ordered
- [x] I have verified the link works
- [x] `awesome-lint` passes locally (or the CI check is green)
- [x] `lychee` passes locally (or the CI check is green)

## Tool Information (for additions)
- **Name**: DaoXE
- **URL**: https://daoxe.com
- **Category**: LLM Tools & Frameworks
- **Description**: Multi-model, multi-protocol AI API gateway (OpenAI Chat Completions/Responses, Anthropic Messages, image endpoints).

## License Acknowledgment
By submitting this PR, I dedicate my contribution to the public domain under the [CC0 1.0 Universal](../LICENSE) dedication used by this Awesome list.

## Additional Notes
Disclosure: I am affiliated with DaoXE. The service is not available in mainland China. Model IDs, pricing, and availability depend on the live account catalog rather than a hardcoded list.
