### PR TITLE
Add Hivekeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The fastest-moving corner of the field in 2026: autonomous and semi-autonomous s
 - [AgentScope](https://github.com/modelscope/agentscope) - Multi-agent platform with distributed orchestration and visual debugging.
 - [Letta](https://www.letta.com/) - Framework for stateful agents with long-term memory (formerly MemGPT).
 - [Browser Use](https://github.com/browser-use/browser-use) - Library that lets agents control a real browser to complete web tasks.
+- [Hivekeep](https://github.com/MarlBurroW/hivekeep) - Self-hosted platform to run a team of AI agents with memory, a web UI, and chat channels.
 
 ## Productivity
 


### PR DESCRIPTION
Adds Hivekeep under AI Agents.

Hivekeep is a self-hosted, MIT-licensed platform to run a team of specialized AI agents with persistent memory and a web UI; agents collaborate and build their own tools, mini-apps and plugins, and are reachable over Telegram, Slack, Discord and Matrix from a single container (Bun + SQLite).

Repo: https://github.com/MarlBurroW/hivekeep

Follows CONTRIBUTING: single line, description under 120 chars, capitalized, ends with a period. Disclosure: I am the author of Hivekeep.

## Summary by Sourcery

Documentation:
- Add Hivekeep to the AI Agents section of the README as a self-hosted multi-agent platform option.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Hivekeep to the AI Agents section of the README with a one-line description and link to the repo.
Highlights a self-hosted multi-agent platform with persistent memory, a web UI, and chat integrations.

<sup>Written for commit 45496467e280bad76c57c8052b6ddfcc8544ec76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aliammari1/awesome-ai-tools/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Hivekeep to the AI Agents directory with its website and a brief description of its self-hosted platform, agent memory, web interface, and chat channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->