### PR TITLE
Add Atomic Agent to AI Agents and AI Coding Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The fastest-moving corner of the field in 2026: autonomous and semi-autonomous s
 - [AgentScope](https://github.com/modelscope/agentscope) - Multi-agent platform with distributed orchestration and visual debugging.
 - [Letta](https://www.letta.com/) - Framework for stateful agents with long-term memory (formerly MemGPT).
 - [Browser Use](https://github.com/browser-use/browser-use) - Library that lets agents control a real browser to complete web tasks.
+- [Atomic Agent](https://atomicagent.io) - Local-first CLI and TUI agent running open-weight models on your machine, with MCP and 56 tools.
 
 ## Productivity
 
@@ -392,6 +393,7 @@ The fastest-moving corner of the field in 2026: autonomous and semi-autonomous s
 - [Continue.dev](https://continue.dev/) - Open-source AI coding assistant for VS Code & JetBrains with custom models.
 - [Aider](https://aider.chat/) - Open-source AI pair programmer for terminal with Git integration.
 - [CodeT5](https://github.com/salesforce/CodeT5) - Open-source code generation by Salesforce.
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - Open-source terminal coding assistant running local models, no account or API key needed.
 
 ### Development Tools
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ The fastest-moving corner of the field in 2026: autonomous and semi-autonomous s
 - [AgentScope](https://github.com/modelscope/agentscope) - Multi-agent platform with distributed orchestration and visual debugging.
 - [Letta](https://www.letta.com/) - Framework for stateful agents with long-term memory (formerly MemGPT).
 - [Browser Use](https://github.com/browser-use/browser-use) - Library that lets agents control a real browser to complete web tasks.
-- [Atomic Agent](https://atomicagent.io) - Local-first CLI and TUI agent running open-weight models on your machine, with MCP and 56 tools.
 
 ## Productivity
 


### PR DESCRIPTION
## Description

Hi! I'm the CPO of Atomic Agent, and thanks for this great list. It's genuinely one of the better-curated AI tool maps out there, and our team would be thrilled if you added us.

Atomic Agent is an open-source, local-first CLI and TUI coding assistant. It runs open-weight models entirely on your machine through a llama.cpp fork, so there's no account or API key required to install and run it. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, has a five-layer local memory system, and runs on macOS, Linux, and Windows. The TUI is built on React and ink.

Install: `curl -fsSL https://atomicagent.io/install | sh`

I've added it to two subcategories, since it genuinely sits in both and your **AI Agents** intro explicitly cross-references coding agents:

- **AI Agents** - as a local-first agent with MCP and a tool suite.
- **Code Generation & Development › AI Coding Assistants** - as a terminal coding assistant, alongside Aider and Claude Code.

Happy to drop one of the two if you'd rather keep single-listing, just say the word.

One honest note on scope: the project's README carries an official "Developer preview. APIs, commands, config, and behavior are still moving" notice, so interfaces are not frozen yet. It's real, installable, and actively developed (MIT, ~2k stars, not archived), but I'd rather flag that up front than have you find out later. Repo is ~4 months old, maintained by the AtomicBot-ai organization.

Other links, in case they're useful: docs https://atomicagent.io/docs · Discord https://discord.gg/Us7qXtDGw · X https://x.com/atomicagent_io

## Type of Change
- [x] Adding a new AI tool
- [ ] Updating existing tool information
- [ ] Fixing a broken link
- [ ] Re-categorizing a tool
- [ ] Documentation improvement
- [ ] Other: ___________

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] The tool meets our quality criteria (active, reputable, functional)
- [x] The description follows our format: `- [Name](URL) - Description.`
- [x] Description is under 120 characters
- [x] The entry is in the most specific subcategory (ordering matches the existing curated order of those sections, see Additional Notes)
- [x] I have verified the link works
- [x] `awesome-lint` passes locally (or the CI check is green)
- [x] `lychee` passes locally (or the CI check is green)

## Tool Information (for additions)
- **Name**: Atomic Agent
- **URL**: https://atomicagent.io (repo: https://github.com/AtomicBot-ai/atomic-agent)
- **Category**: AI Agents; Code Generation & Development › AI Coding Assistants
- **Description**: Local-first CLI and TUI agent running open-weight models on your machine, with MCP and 56 tools.

## License Acknowledgment
By submitting this PR, I dedicate my contribution to the public domain under the [CC0 1.0 Universal](../LICENSE) dedication used by this Awesome list.

## Additional Notes

On ordering: I appended each entry to the end of its subcategory, matching how the existing lists are actually ordered in `README.md` (both **AI Agents** and **AI Coding Assistants** are in curated rather than strict alphabetical order, and recently merged tool additions followed the same append pattern). Happy to move either line if you'd prefer strict alphabetical placement.

I ran `npx awesome-lint` locally against the edited `README.md` and it passes with no errors. Both links return 200. I only edited the English `README.md`, since CONTRIBUTING notes the docs-site translations are generated from it automatically.

## Summary by Sourcery

Add Atomic Agent as a new AI tool entry in both the AI Agents and AI Coding Assistants sections of the README.

New Features:
- List Atomic Agent in the AI Agents category as a local-first CLI/TUI agent with MCP and integrated tools.
- List Atomic Agent in the AI Coding Assistants category as an open-source terminal coding assistant running local models without accounts or API keys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Atomic Agent as a single entry under Code Generation › AI Coding Assistants. This replaces the earlier dual-listing approach to follow the single-list policy.

- Adds one line to `README.md` at the end of the AI Coding Assistants list; adjust ordering if you prefer alphabetical.
- Description stays under 120 chars; link returns 200; `awesome-lint` and `lychee` pass locally.
- The project is marked “Developer preview”; confirm it meets inclusion policy.

<sup>Written for commit be383ab02431b0ac87c95ec9f87e4d9633f44a3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aliammari1/awesome-ai-tools/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Atomic Agent to the list of AI agents.
  * Added Atomic Agent to the list of AI coding assistants, highlighting local model support and terminal-based usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->