### PR TITLE
Add Wordsmith to Writing Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The fastest-moving corner of the field in 2026: autonomous and semi-autonomous s
 - [Koala Writer](https://koala.sh/) - AI article writer with SEO optimization and real-time data.
 - [QuillBot](https://quillbot.com/) - AI paraphrasing, grammar, and plagiarism checker with Co-Writer.
 - [ProWritingAid](https://prowritingaid.com/) - Writing editor with AI analysis and style suggestions.
+- [Wordsmith](https://wordsmith.page/) - Whole-manuscript developmental editing with an editorial letter, comments, and tracked changes.
 - [Wordtune](https://www.wordtune.com/) - AI writing companion with rewriting, summarization, and tone adjustment.
 - [Writer](https://writer.com/) - AI writing platform for teams with brand consistency and Palmyra LLMs.
 - [Anyword](https://anyword.com/) - AI copywriting with performance prediction and brand voice.


### PR DESCRIPTION
## Description

Wordsmith (https://wordsmith.page/) reads complete manuscripts and returns developmental feedback grounded in the writer's text. More than 100 writers are already writing with us. This pull request adds one factual, 95-character entry to Writing Assistants and keeps the link free of affiliate or tracking parameters. Would this fit the list's quality bar? If not a fit, please close it and we will leave it there. Disclosure: this submission is from the product team and was prepared with Codex assistance.

## Type of Change

- [x] Adding a new AI tool
- [ ] Updating existing tool information
- [ ] Fixing a broken link
- [ ] Re-categorizing a tool
- [ ] Documentation improvement
- [ ] Other: ___________

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] The tool meets our quality criteria (active, reputable, functional)
- [x] The description follows our format: `- [Name](URL) - Description.`
- [x] Description is under 120 characters
- [x] The entry is in the most specific subcategory and alphabetically ordered
- [x] I have verified the link works
- [ ] `awesome-lint` passes locally (or the CI check is green)
- [ ] `lychee` passes locally (or the CI check is green)

## Tool Information (for additions)

- **Name**: Wordsmith
- **URL**: https://wordsmith.page/
- **Category**: Communication & Writing / Writing Assistants
- **Description**: Whole-manuscript developmental editing with an editorial letter, comments, and tracked changes.

## License Acknowledgment

By submitting this PR, I dedicate my contribution to the public domain under the [CC0 1.0 Universal](../LICENSE) dedication used by this Awesome list.

## Additional Notes

The one-line diff passes `git diff --check`. The repository's CI remains the authoritative `awesome-lint` and `lychee` check.

## Summary by Sourcery

New Features:
- Add Wordsmith to the Writing Assistants list with a concise description of its manuscript developmental editing capabilities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Wordsmith to Writing Assistants to cover whole‑manuscript developmental editing. Uses the standard entry format and a tracking‑free link.

- Single-line addition in README under Communication & Writing → Writing Assistants; placed alphabetically.
- Description follows `- [Name](URL) - Description.` and stays under the character limit.

<sup>Written for commit b0d52c296de82891432813ba71946874846f8a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aliammari1/awesome-ai-tools/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Wordsmith to the Writing Assistants section.
  * Described its manuscript developmental editing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->