### PR TITLE
Add Piclisto Product Page Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ The fastest-moving corner of the field in 2026: autonomous and semi-autonomous s
 ### E-commerce & Retail
 
 - [Dynamic Yield](https://www.dynamicyield.com/) - Personalization platform.
+- [Piclisto Product Page Kit](https://piclisto.com/product-page-kit) - Creates reviewable PDP and Amazon A+ image modules from one product SKU.
 - [Yotpo](https://www.yotpo.com/) - Customer reviews and loyalty.
 - [Klevu](https://www.klevu.com/) - AI-powered site search.
 - [Searchspring](https://searchspring.com/) - E-commerce search and merchandising.


### PR DESCRIPTION
Adds Piclisto Product Page Kit to E-commerce & Retail. I am submitting it on behalf of the product team. The linked page is public and describes a review-first workflow for PDP, Amazon A+, and Shopify product-page image modules.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Piclisto Product Page Kit to the E-commerce & Retail list in the README. The kit creates reviewable PDP and Amazon A+ image modules from a single product SKU.

<sup>Written for commit 2ccd1ce5cf68006150fa2c683d8dfa0cb3fdef0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aliammari1/awesome-ai-tools/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Add Piclisto Product Page Kit to the curated E-commerce & Retail tools.

New Features:
- Add Piclisto Product Page Kit to the E-commerce & Retail resources list.

Documentation:
- Document Piclisto Product Page Kit as a tool for creating reviewable PDP and Amazon A+ image modules from a product SKU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Piclisto Product Page Kit to the E-commerce & Retail resources list.
  * Included a link and description highlighting product detail page and Amazon A+ image module creation from a single SKU.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->