### PR TITLE
Add ResumeAI to Career & Job Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ The fastest-moving corner of the field in 2026: autonomous and semi-autonomous s
 - [Jobscan](https://www.jobscan.co/) - Resume and LinkedIn optimization with ATS keyword matching.
 - [Resume Worded](https://resumeworded.com/) - AI resume and LinkedIn feedback with score and targeted advice.
 - [Kickresume](https://www.kickresume.com/) - AI resume builder with templates and job matching.
+- [ResumeAI](https://withresumeai.com/) - Free ATS checker (3/day no account, 10/day free account) and AI resume builder; State of ATS 2026 dataset (738 employers, 704 portal-verified; Workday 37.9%).
 
 
 


### PR DESCRIPTION
Adds [ResumeAI](https://withresumeai.com/) to **Career & Job Search**.

- Free ATS checker (3/day no account, 10/day free account) and AI resume builder
- State of ATS 2026: 738 employers, 704 portal-verified; Workday 37.9%

Disclosure: I am the founder. Canonical domain withresumeai.com (not resume.ai).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ResumeAI to the Career & Job Search section of the README, listing its free ATS checker and AI resume builder alongside existing tools. Also includes a State of ATS 2026 dataset with employer and portal-verified counts.

Disclosure: the PR author is the founder of ResumeAI.

<sup>Written for commit fe435a0d40d8ab88456201418e7895616c0c3685. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/aliammari1/awesome-ai-tools/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ResumeAI to the Career & Job Search resources.
  * Documented its ATS checker limits, resume builder, and 2026 ATS dataset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->